### PR TITLE
Start the server in the install phase with start profile

### DIFF
--- a/microservice-vote/pom.xml
+++ b/microservice-vote/pom.xml
@@ -124,14 +124,14 @@
                                     <goal>start-server</goal>
                                 </goals>
                             </execution>                                                                   
-                        </executions>
-                        <!-- 
-                        <configuration>
-                            <serverName>uiServer</serverName>
-                            <appArchive>${project.build.directory}/${warfile.name}.war</appArchive>
-                            <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
-                        </configuration>
-                        -->
+                            <execution>
+                                <id>start-vote-after-install</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>start-server</goal>
+                                </goals>
+                            </execution>
+                        </executions> 
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This is to workaround an issue with the integration tests. There is
probably a better solution in the future.
Before the change:
mvn install -P start would:
 - package the server
 - start the server
 - run the integration tests (which starts and then stops the server)
So the server wouldn't actually be running at the end of the build.