### PR TITLE
Update for 17004 and fix shrinkwrap war name

### DIFF
--- a/microservice-speaker/pom.xml
+++ b/microservice-speaker/pom.xml
@@ -52,7 +52,7 @@
                         </executions>
                         <configuration>
                             <serverName>speakerServer</serverName>
-                            <appArchive>${project.build.directory}/${warfile.name}.war</appArchive>
+                            <appArchive>${project.build.directory}/_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest.war</appArchive>
                             <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
                         </configuration>                        
                     </plugin>
@@ -79,15 +79,13 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>
-                                ${project.build.directory}/liberty/${liberty.root}usr/servers/speakerServer/apps
-                            </outputDirectory>
+                            <outputDirectory>${project.build.directory}/liberty/${liberty.root}usr/servers/speakerServer/apps</outputDirectory>
                             <overwrite>true</overwrite>
                             <resources>
                                 <resource>
                                     <directory>${project.build.directory}</directory>
                                     <includes>
-                                        <include>${warfile.name}.war</include>
+                                        <include>_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest.war</include>
                                     </includes>
                                 </resource>
                             </resources>
@@ -127,7 +125,7 @@
                 </executions>
                 <configuration>
                     <serverName>speakerServer</serverName>
-                    <appArchive>${project.build.directory}/${warfile.name}.war</appArchive>
+                    <appArchive>${project.build.directory}/_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest.war</appArchive>
                     <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
                 </configuration>
             </plugin>

--- a/microservice-speaker/pom.xml
+++ b/microservice-speaker/pom.xml
@@ -30,6 +30,11 @@
     <description>The Speaker microservice resource</description>
     <packaging>war</packaging>
 
+
+    <properties>
+        <shrinkwrapWarfile.name>_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest</shrinkwrapWarfile.name>
+    </properties>
+
     <profiles>
         <profile>
             <id>start</id>
@@ -52,7 +57,7 @@
                         </executions>
                         <configuration>
                             <serverName>speakerServer</serverName>
-                            <appArchive>${project.build.directory}/_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest.war</appArchive>
+                            <appArchive>${project.build.directory}/${shrinkwrapWarfile.name}.war</appArchive>
                             <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
                         </configuration>                        
                     </plugin>
@@ -85,7 +90,7 @@
                                 <resource>
                                     <directory>${project.build.directory}</directory>
                                     <includes>
-                                        <include>_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest.war</include>
+                                        <include>${shrinkwrapWarfile.name}.war</include>
                                     </includes>
                                 </resource>
                             </resources>
@@ -125,7 +130,7 @@
                 </executions>
                 <configuration>
                     <serverName>speakerServer</serverName>
-                    <appArchive>${project.build.directory}/_DEFAULT___DEFAULT__io.microprofile.showcase.speaker.rest.ResourceSpeakerTest.war</appArchive>
+                    <appArchive>${project.build.directory}/${shrinkwrapWarfile.name}.war</appArchive>
                     <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
                 </configuration>
             </plugin>
@@ -136,6 +141,12 @@
                 <configuration>
                     <argLine>-Dwlp.home=${project.build.directory}/liberty/${liberty.root}</argLine>
                 </configuration>
+            </plugin>
+            <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <configuration>
+                      <skip>true</skip>
+                    </configuration>
             </plugin>
             
         </plugins>
@@ -154,7 +165,7 @@
         <dependency>
             <groupId>io.microprofile.showcase</groupId>
             <artifactId>demo-bootstrap</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- JAVA EE -->

--- a/microservice-speaker/src/main/liberty/config/server.xml
+++ b/microservice-speaker/src/main/liberty/config/server.xml
@@ -20,5 +20,5 @@
 
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="4040" />
 
-    <webApplication location="ROOT.war" contextRoot="/"/>
+    <!-- <webApplication location="ROOT.war" contextRoot="/"/> -->
 </server>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.jackson>2.8.2</version.jackson>
 
         <!-- App servers -->
-        <version.liberty>17.0.0.3</version.liberty>
+        <version.liberty>17.0.0.4</version.liberty>
 
         <!-- Dependencies -->
         <version.javaee>7.0</version.javaee>


### PR DESCRIPTION
The "speaker" module uses Shrinkwrap testing, that creates an archive using an embedded resolver name.  I adjusted the pom.xml in this case to reflect the archive name generated.

I also moved the sample up to open liberty 17.0.0.4